### PR TITLE
fix: chmod node-pty spawn-helper in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"src/pwa/icons/",
 		"README.md",
 		"CHANGELOG.md",
-		"LICENSE"
+		"LICENSE",
+		"scripts/postinstall.mjs"
 	],
 	"publishConfig": {
 		"provenance": true
@@ -55,7 +56,8 @@
 		"test:pw:chromium": "playwright test --project=chromium-android",
 		"test:pw:webkit": "playwright test --project=webkit-iphone",
 		"release": "semantic-release",
-		"prepublishOnly": "pnpm run lint:ox && pnpm run lint:knip && pnpm run build:dist && pnpm run lint:publint"
+		"prepublishOnly": "pnpm run lint:ox && pnpm run lint:knip && pnpm run build:dist && pnpm run lint:publint",
+		"postinstall": "node scripts/postinstall.mjs"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.0",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,14 @@
+import { chmodSync, existsSync } from "node:fs"
+import { createRequire } from "node:module"
+import { join, dirname } from "node:path"
+
+const require = createRequire(import.meta.url)
+try {
+  const ptyDir = dirname(require.resolve("node-pty/package.json"))
+  for (const arch of ["darwin-arm64", "darwin-x64"]) {
+    const helper = join(ptyDir, "prebuilds", arch, "spawn-helper")
+    if (existsSync(helper)) chmodSync(helper, 0o755)
+  }
+} catch {
+  // node-pty not found, skip
+}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,3 +1,6 @@
+// Workaround for microsoft/node-pty#850 — spawn-helper prebuild ships without
+// execute permission on macOS, causing "posix_spawnp failed" at runtime.
+// Remove this script once node-pty >=1.2.0 stable is released and we upgrade.
 import { chmodSync, existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,14 +1,14 @@
-import { chmodSync, existsSync } from "node:fs"
-import { createRequire } from "node:module"
-import { join, dirname } from "node:path"
+import { chmodSync, existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
 
 const require = createRequire(import.meta.url)
 try {
-  const ptyDir = dirname(require.resolve("node-pty/package.json"))
-  for (const arch of ["darwin-arm64", "darwin-x64"]) {
-    const helper = join(ptyDir, "prebuilds", arch, "spawn-helper")
-    if (existsSync(helper)) chmodSync(helper, 0o755)
-  }
+	const ptyDir = dirname(require.resolve('node-pty/package.json'))
+	for (const arch of ['darwin-arm64', 'darwin-x64']) {
+		const helper = join(ptyDir, 'prebuilds', arch, 'spawn-helper')
+		if (existsSync(helper)) chmodSync(helper, 0o755)
+	}
 } catch {
-  // node-pty not found, skip
+	// node-pty not found, skip
 }


### PR DESCRIPTION
Fixes #21

## Summary

- Adds `scripts/postinstall.mjs` that chmods the node-pty `spawn-helper` prebuild to be executable after install
- Updates `package.json` to run the postinstall script and include it in published files
- Workaround for upstream microsoft/node-pty#850 until 1.2.0 stable lands

## Problem

On macOS, `npm install -g remobi` installs node-pty's `spawn-helper` binary without execute permission (`-rw-r--r--`). This causes `remobi serve` to crash immediately with `posix_spawnp failed`.

## Fix

A postinstall script resolves the node-pty package location and chmods `spawn-helper` for both `darwin-arm64` and `darwin-x64` prebuilds. Silently skips if node-pty is not found.

## Test plan

- [ ] `npm install -g remobi` on macOS arm64, verify `remobi serve` starts without error
- [ ] Verify spawn-helper has `+x` after install
- [ ] Verify no-op on Linux (no darwin prebuilds to chmod)